### PR TITLE
Generally finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ kubectl apply -f assets/sample_service.yaml
 
 ### Create your own PaddleService
 
-Imitate ```config/samples/elasticserving_v1_paddle.yaml``` to create your own PaddleService.  Please follow the following format.
+After insntalling CRD ```kubectl apply -f assets/crd.yaml``` and controller manager ```kubectl apply -f assets/elasticserving_operator.yaml```, you can build your own PaddleService by applying your yaml which looks like the following one.
 
 example.yaml
 

--- a/assets/crd.yaml
+++ b/assets/crd.yaml
@@ -63,9 +63,6 @@ spec:
               - port
               - tag
               type: object
-            deploymentName:
-              maxLength: 64
-              type: string
             resources:
               properties:
                 limits:
@@ -117,7 +114,6 @@ spec:
               type: object
           required:
           - default
-          - deploymentName
           type: object
         status:
           properties:

--- a/assets/crd.yaml
+++ b/assets/crd.yaml
@@ -130,6 +130,11 @@ spec:
               additionalProperties:
                 type: string
               type: object
+            canary:
+              properties:
+                name:
+                  type: string
+              type: object
             conditions:
               items:
                 properties:
@@ -152,8 +157,6 @@ spec:
               type: array
             default:
               properties:
-                host:
-                  type: string
                 name:
                   type: string
               type: object

--- a/assets/elasticserving_operator.yaml
+++ b/assets/elasticserving_operator.yaml
@@ -137,6 +137,11 @@ spec:
               additionalProperties:
                 type: string
               type: object
+            canary:
+              properties:
+                name:
+                  type: string
+              type: object
             conditions:
               items:
                 properties:
@@ -159,8 +164,6 @@ spec:
               type: array
             default:
               properties:
-                host:
-                  type: string
                 name:
                   type: string
               type: object

--- a/assets/elasticserving_operator.yaml
+++ b/assets/elasticserving_operator.yaml
@@ -70,9 +70,6 @@ spec:
               - port
               - tag
               type: object
-            deploymentName:
-              maxLength: 64
-              type: string
             resources:
               properties:
                 limits:
@@ -124,7 +121,6 @@ spec:
               type: object
           required:
           - default
-          - deploymentName
           type: object
         status:
           properties:

--- a/assets/sample_service.yaml
+++ b/assets/sample_service.yaml
@@ -21,7 +21,7 @@ spec:
   default:
     arg: python3 Serving/python/examples/lac/lac_web_service.py lac_model/ lac_workdir
       9292
-    containerImage: jinmionhaobaidu/pdservinglac
+    containerImage: jinmionhaobaidu/pdservinglaccanary
     port: 9292
     tag: latest
   deploymentName: paddleservice

--- a/assets/sample_service.yaml
+++ b/assets/sample_service.yaml
@@ -21,10 +21,9 @@ spec:
   default:
     arg: python3 Serving/python/examples/lac/lac_web_service.py lac_model/ lac_workdir
       9292
-    containerImage: jinmionhaobaidu/pdservinglaccanary
+    containerImage: jinmionhaobaidu/pdservinglac
     port: 9292
     tag: latest
-  deploymentName: paddleservice
   runtimeVersion: paddleserving
   service:
-    minScale: 1
+    minScale: 0

--- a/config/crd/bases/elasticserving.paddlepaddle.org_paddleservices.yaml
+++ b/config/crd/bases/elasticserving.paddlepaddle.org_paddleservices.yaml
@@ -132,6 +132,11 @@ spec:
               additionalProperties:
                 type: string
               type: object
+            canary:
+              properties:
+                name:
+                  type: string
+              type: object
             conditions:
               items:
                 properties:
@@ -154,8 +159,6 @@ spec:
               type: array
             default:
               properties:
-                host:
-                  type: string
                 name:
                   type: string
               type: object

--- a/config/crd/bases/elasticserving.paddlepaddle.org_paddleservices.yaml
+++ b/config/crd/bases/elasticserving.paddlepaddle.org_paddleservices.yaml
@@ -65,9 +65,6 @@ spec:
               - port
               - tag
               type: object
-            deploymentName:
-              maxLength: 64
-              type: string
             resources:
               properties:
                 limits:
@@ -119,7 +116,6 @@ spec:
               type: object
           required:
           - default
-          - deploymentName
           type: object
         status:
           properties:

--- a/config/samples/elasticserving_v1_paddle.yaml
+++ b/config/samples/elasticserving_v1_paddle.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: paddleservice-system
 spec:
   # Add fields here
-  deploymentName: paddleservice
   runtimeVersion: paddleserving
   default:
     containerImage: "jinmionhaobaidu/pdservinglac"
@@ -21,4 +20,4 @@ spec:
       python3 Serving/python/examples/lac/lac_web_service_canary.py lac_model/ lac_workdir 9292
   canaryTrafficPercent: 50
   service:
-    minScale: 1
+    minScale: 0

--- a/pkg/apis/elasticserving/v1/paddleservice_status.go
+++ b/pkg/apis/elasticserving/v1/paddleservice_status.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
@@ -58,25 +57,25 @@ func (ss *PaddleServiceStatus) GetCondition(t apis.ConditionType) *apis.Conditio
 }
 
 func (ss *PaddleServiceStatus) PropagateStatus(serviceStatus *knservingv1.ServiceStatus) {
-	conditionType := DefaultEndpointReady
+	// conditionType := DefaultEndpointReady
 	statusSpec := StatusConfigurationSpec{}
-	if ss.Default == nil {
-		ss.Default = &statusSpec
-	}
-	if serviceStatus == nil {
-		return
-	}
-	statusSpec.Name = serviceStatus.LatestCreatedRevisionName
-	serviceCondition := serviceStatus.GetCondition(knservingv1.ServiceConditionReady)
+	// if ss.Default == nil {
+	// 	ss.Default = &statusSpec
+	// }
+	// if serviceStatus == nil {
+	// 	return
+	// }
+	// statusSpec.Name = serviceStatus.LatestCreatedRevisionName
+	// serviceCondition := serviceStatus.GetCondition(knservingv1.ServiceConditionReady)
 
-	switch {
-	case serviceCondition == nil:
-	case serviceCondition.Status == v1.ConditionUnknown:
-		conditionSet.Manage(ss).MarkUnknown(conditionType, serviceCondition.Reason, serviceCondition.Message)
-	case serviceCondition.Status == v1.ConditionTrue:
-		conditionSet.Manage(ss).MarkTrue(conditionType)
-	case serviceCondition.Status == v1.ConditionFalse:
-		conditionSet.Manage(ss).MarkFalse(conditionType, serviceCondition.Reason, serviceCondition.Message)
-	}
+	// switch {
+	// case serviceCondition == nil:
+	// case serviceCondition.Status == v1.ConditionUnknown:
+	// 	conditionSet.Manage(ss).MarkUnknown(conditionType, serviceCondition.Reason, serviceCondition.Message)
+	// case serviceCondition.Status == v1.ConditionTrue:
+	// 	conditionSet.Manage(ss).MarkTrue(conditionType)
+	// case serviceCondition.Status == v1.ConditionFalse:
+	// 	conditionSet.Manage(ss).MarkFalse(conditionType, serviceCondition.Reason, serviceCondition.Message)
+	// }
 	*ss.Default = statusSpec
 }

--- a/pkg/apis/elasticserving/v1/paddleservice_status.go
+++ b/pkg/apis/elasticserving/v1/paddleservice_status.go
@@ -57,13 +57,13 @@ func (ss *PaddleServiceStatus) GetCondition(t apis.ConditionType) *apis.Conditio
 }
 
 func (ss *PaddleServiceStatus) PropagateStatus(serviceStatus *knservingv1.ServiceStatus) {
+	if serviceStatus == nil {
+		return
+	}
 	// conditionType := DefaultEndpointReady
 	statusSpec := StatusConfigurationSpec{}
 	if ss.Default == nil {
 		ss.Default = &statusSpec
-	}
-	if serviceStatus == nil {
-		return
 	}
 	statusSpec.Name = serviceStatus.LatestCreatedRevisionName
 	// serviceCondition := serviceStatus.GetCondition(knservingv1.ServiceConditionReady)
@@ -75,7 +75,7 @@ func (ss *PaddleServiceStatus) PropagateStatus(serviceStatus *knservingv1.Servic
 	// case serviceCondition.Status == v1.ConditionTrue:
 	// 	conditionSet.Manage(ss).MarkTrue(conditionType)
 	// case serviceCondition.Status == v1.ConditionFalse:
-	// 	// 	conditionSet.Manage(ss).MarkFalse(conditionType, serviceCondition.Reason, serviceCondition.Message)
+	// 	conditionSet.Manage(ss).MarkFalse(conditionType, serviceCondition.Reason, serviceCondition.Message)
 	// }
 	*ss.Default = statusSpec
 }

--- a/pkg/apis/elasticserving/v1/paddleservice_status.go
+++ b/pkg/apis/elasticserving/v1/paddleservice_status.go
@@ -59,23 +59,23 @@ func (ss *PaddleServiceStatus) GetCondition(t apis.ConditionType) *apis.Conditio
 func (ss *PaddleServiceStatus) PropagateStatus(serviceStatus *knservingv1.ServiceStatus) {
 	// conditionType := DefaultEndpointReady
 	statusSpec := StatusConfigurationSpec{}
-	// if ss.Default == nil {
-	// 	ss.Default = &statusSpec
-	// }
-	// if serviceStatus == nil {
-	// 	return
-	// }
-	// statusSpec.Name = serviceStatus.LatestCreatedRevisionName
+	if ss.Default == nil {
+		ss.Default = &statusSpec
+	}
+	if serviceStatus == nil {
+		return
+	}
+	statusSpec.Name = serviceStatus.LatestCreatedRevisionName
 	// serviceCondition := serviceStatus.GetCondition(knservingv1.ServiceConditionReady)
 
 	// switch {
 	// case serviceCondition == nil:
 	// case serviceCondition.Status == v1.ConditionUnknown:
-	// 	conditionSet.Manage(ss).MarkUnknown(conditionType, serviceCondition.Reason, serviceCondition.Message)
+	// 	conditionSet.Manage(ss).MarkUnknown(conditionType, "serviceCondition.Reason", "string")
 	// case serviceCondition.Status == v1.ConditionTrue:
 	// 	conditionSet.Manage(ss).MarkTrue(conditionType)
 	// case serviceCondition.Status == v1.ConditionFalse:
-	// 	conditionSet.Manage(ss).MarkFalse(conditionType, serviceCondition.Reason, serviceCondition.Message)
+	// 	// 	conditionSet.Manage(ss).MarkFalse(conditionType, serviceCondition.Reason, serviceCondition.Message)
 	// }
 	*ss.Default = statusSpec
 }

--- a/pkg/apis/elasticserving/v1/paddleservice_types.go
+++ b/pkg/apis/elasticserving/v1/paddleservice_types.go
@@ -30,8 +30,6 @@ type PaddleServiceSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// +kubebuilder:validation:MaxLength=64
-	DeploymentName string `json:"deploymentName"`
 	// Version of the service
 	RuntimeVersion string `json:"runtimeVersion,omitempty"`
 	// Defaults to requests and limits of 1CPU, 2Gb MEM.

--- a/pkg/apis/elasticserving/v1/paddleservice_types.go
+++ b/pkg/apis/elasticserving/v1/paddleservice_types.go
@@ -101,6 +101,8 @@ type PaddleServiceStatus struct {
 	URL string `json:"url,omitempty"`
 	// Statuses for the default endpoints of the PaddleService
 	Default *StatusConfigurationSpec `json:"default,omitempty"`
+	// Statuses for the canary endpoints of the PaddleService
+	Canary *StatusConfigurationSpec `json:"canary,omitempty"`
 	// Addressable URL for eventing
 	Address *duckv1beta1.Addressable `json:"address,omitempty"`
 
@@ -135,8 +137,6 @@ type PaddleServiceList struct {
 type StatusConfigurationSpec struct {
 	// Latest revision name that is in ready state
 	Name string `json:"name,omitempty"`
-	// Host name of the service
-	Hostname string `json:"host,omitempty"`
 }
 
 func init() {

--- a/pkg/apis/elasticserving/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/elasticserving/v1/zz_generated.deepcopy.go
@@ -140,6 +140,11 @@ func (in *PaddleServiceStatus) DeepCopyInto(out *PaddleServiceStatus) {
 		*out = new(StatusConfigurationSpec)
 		**out = **in
 	}
+	if in.Canary != nil {
+		in, out := &in.Canary, &out.Canary
+		*out = new(StatusConfigurationSpec)
+		**out = **in
+	}
 	if in.Address != nil {
 		in, out := &in.Address, &out.Address
 		*out = new(v1beta1.Addressable)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -20,8 +20,8 @@ const (
 var (
 	PaddleServiceDefaultCPU                               = "0.2"
 	PaddleServiceDefaultMemory                            = "512Mi"
-	PaddleServiceDefaultMinScale                          = 1  // 0 if scale-to-zero is desired
-	PaddleServiceDefaultMaxScale                          = 10 // 0 means limitless
+	PaddleServiceDefaultMinScale                          = 0 // 0 if scale-to-zero is desired
+	PaddleServiceDefaultMaxScale                          = 0 // 0 means limitless
 	PaddleServiceDefaultTimeout                     int64 = 300
 	PaddleServiceDefaultScalingClass                      = autoscaling.KPA // kpa or hpa
 	PaddleServiceDefaultScalingMetric                     = "concurrency"   // concurrency, rps or cpu (hpa required)
@@ -30,6 +30,7 @@ var (
 	PaddleServiceDefaultWindow                            = "60s"
 	PaddleServiceDefaultPanicWindow                       = "10" // percentage of StableWindow
 	PaddleServiceDefaultPanicThreshold                    = "200"
+	PaddleServivceDefaultTrafficPercents                  = 50
 )
 
 var (

--- a/pkg/controllers/elasticserving/paddleflow_serving_controller.go
+++ b/pkg/controllers/elasticserving/paddleflow_serving_controller.go
@@ -55,7 +55,6 @@ func (r *PaddleServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 
 	// Load the PaddleService by name
 	var paddlesvc elasticservingv1.PaddleService
-	log.Info("First", "First", paddlesvc)
 	if err := r.Get(ctx, req.NamespacedName, &paddlesvc); err != nil {
 		log.Error(err, "unable to fetch PaddleService")
 		// we'll ignore not-found errors, since they can't be fixed by an immediate
@@ -75,7 +74,6 @@ func (r *PaddleServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	}
 
 	// Update status
-	log.Info("Last", "Last", paddlesvc)
 	if err := r.Status().Update(ctx, &paddlesvc); err != nil {
 		r.Recorder.Eventf(&paddlesvc, core.EventTypeWarning, "InternalError", err.Error())
 		return ctrl.Result{}, err

--- a/pkg/controllers/elasticserving/reconcilers/knative/service_reconciler.go
+++ b/pkg/controllers/elasticserving/reconcilers/knative/service_reconciler.go
@@ -67,12 +67,11 @@ func (r *ServiceReconciler) Reconcile(paddlesvc *elasticservingv1.PaddleService)
 		return nil
 	}
 
-	if status, err := r.reconcileDefaultEndpoint(paddlesvc, service); err != nil {
+	if _, err := r.reconcileDefaultEndpoint(paddlesvc, service); err != nil {
 		return err
 	} else {
 		// TODO: Modify status
-		log.Info("STATUSTAT", "STATUS", status)
-		paddlesvc.Status.PropagateStatus(status)
+		// paddlesvc.Status.PropagateStatus(status)
 	}
 
 	serviceWithCanary, err = r.serviceBuilder.CreateService(serviceName, paddlesvc, true)

--- a/pkg/controllers/elasticserving/reconcilers/knative/service_reconciler.go
+++ b/pkg/controllers/elasticserving/reconcilers/knative/service_reconciler.go
@@ -71,6 +71,7 @@ func (r *ServiceReconciler) Reconcile(paddlesvc *elasticservingv1.PaddleService)
 		return err
 	} else {
 		// TODO: Modify status
+		log.Info("STATUSSSS", "STATUSSSS", paddlesvc.Status)
 		// paddlesvc.Status.PropagateStatus(status)
 	}
 
@@ -226,6 +227,7 @@ func (r *ServiceReconciler) reconcileCanaryEndpoint(paddlesvc *elasticservingv1.
 	if err != nil {
 		return nil, err
 	}
+
 	desiredRevision, err := r.serviceBuilder.CreateRevision(constants.CanaryServiceName(desired.Name), paddlesvc, true)
 	if err != nil {
 		return nil, err
@@ -242,7 +244,8 @@ func (r *ServiceReconciler) reconcileCanaryEndpoint(paddlesvc *elasticservingv1.
 		return &existing.Status, nil
 	}
 
-	if err = r.finalizeCanaryEndpoint(paddlesvc.Name, paddlesvc.Namespace, serviceSpec); err != nil {
+	err = r.finalizeCanaryEndpoint(paddlesvc.Name, paddlesvc.Namespace, serviceSpec)
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/controllers/elasticserving/reconcilers/knative/service_reconciler.go
+++ b/pkg/controllers/elasticserving/reconcilers/knative/service_reconciler.go
@@ -130,7 +130,7 @@ func (r *ServiceReconciler) finalizeCanaryEndpoint(serviceName, namespace string
 			return err
 		}
 
-		log.Info("Deleting Knative Service", "namespace", namespace, "name", serviceName)
+		log.Info("Deleting Knative Canary Endpoint", "namespace", namespace, "name", serviceName)
 		if err := r.client.Delete(context.TODO(), existingRevision, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
 			if !errors.IsNotFound(err) {
 				return err
@@ -151,7 +151,7 @@ func (r *ServiceReconciler) reconcileDefaultEndpoint(paddlesvc *elasticservingv1
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			log.Info("Creating Knative Service", "namespace", desired.Namespace, "name", desired.Name)
+			log.Info("Creating Knative Default Endpoint", "namespace", desired.Namespace, "name", desired.Name)
 			err = r.client.Create(context.TODO(), desired)
 			if err != nil {
 				return nil, err
@@ -181,6 +181,9 @@ func (r *ServiceReconciler) reconcileDefaultEndpoint(paddlesvc *elasticservingv1
 		return &existing.Status, nil
 	}
 
+	// The update process includes two steps.
+	// 1. Delete the default endpoint(revision)
+	// 2. Update knative service whose template should be updated to desired.Spec
 	err = r.client.Delete(context.TODO(), existingRevision, client.PropagationPolicy(metav1.DeletePropagationBackground))
 	if err != nil {
 		return nil, err
@@ -254,6 +257,9 @@ func (r *ServiceReconciler) reconcileCanaryEndpoint(paddlesvc *elasticservingv1.
 		return &existing.Status, nil
 	}
 
+	// The update process includes two steps.
+	// 1. Delete the canary endpoint(revision)
+	// 2. Update knative service whose template should be updated to desired.Spec
 	err = r.finalizeCanaryEndpoint(paddlesvc.Name, paddlesvc.Namespace, serviceSpec)
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/elasticserving/resources/knative/service.go
+++ b/pkg/controllers/elasticserving/resources/knative/service.go
@@ -131,16 +131,16 @@ func (r *ServiceBuilder) CreateService(serviceName string, paddlesvc *elasticser
 											},
 										},
 									},
-									// LivenessProbe: &core.Probe{
-									// 	InitialDelaySeconds: constants.LivenessInitialDelaySeconds,
-									// 	FailureThreshold:    constants.LivenessFailureThreshold,
-									// 	PeriodSeconds:       constants.LivenessPeriodSeconds,
-									// 	Handler: core.Handler{
-									// 		TCPSocket: &core.TCPSocketAction{
-									// 			Port: intstr.FromInt(0),
-									// 		},
-									// 	},
-									// },
+									LivenessProbe: &core.Probe{
+										InitialDelaySeconds: constants.LivenessInitialDelaySeconds,
+										FailureThreshold:    constants.LivenessFailureThreshold,
+										PeriodSeconds:       constants.LivenessPeriodSeconds,
+										Handler: core.Handler{
+											TCPSocket: &core.TCPSocketAction{
+												Port: intstr.FromInt(0),
+											},
+										},
+									},
 									Resources: resources,
 								},
 							},
@@ -245,16 +245,16 @@ func (r *ServiceBuilder) CreateRevision(serviceName string, paddlesvc *elasticse
 								},
 							},
 						},
-						// LivenessProbe: &core.Probe{
-						// 	InitialDelaySeconds: constants.LivenessInitialDelaySeconds,
-						// 	FailureThreshold:    constants.LivenessFailureThreshold,
-						// 	PeriodSeconds:       constants.LivenessPeriodSeconds,
-						// 	Handler: core.Handler{
-						// 		TCPSocket: &core.TCPSocketAction{
-						// 			Port: intstr.FromInt(0),
-						// 		},
-						// 	},
-						// },
+						LivenessProbe: &core.Probe{
+							InitialDelaySeconds: constants.LivenessInitialDelaySeconds,
+							FailureThreshold:    constants.LivenessFailureThreshold,
+							PeriodSeconds:       constants.LivenessPeriodSeconds,
+							Handler: core.Handler{
+								TCPSocket: &core.TCPSocketAction{
+									Port: intstr.FromInt(0),
+								},
+							},
+						},
 						Resources: resources,
 					},
 				},

--- a/pkg/controllers/elasticserving/resources/knative/service_test.go
+++ b/pkg/controllers/elasticserving/resources/knative/service_test.go
@@ -22,7 +22,6 @@ const (
 	paddleServiceDefaultMemory = "128Mi"
 	paddleServiceName          = "paddlesvc"
 	paddleServiceNamespace     = "default"
-	deploymentName             = "depl-test"
 	runtimeVersion             = "latest"
 )
 
@@ -68,7 +67,6 @@ var paddlesvc = elasticservingv1.PaddleService{
 		Namespace: paddleServiceNamespace,
 	},
 	Spec: elasticservingv1.PaddleServiceSpec{
-		DeploymentName: deploymentName,
 		RuntimeVersion: runtimeVersion,
 		Resources: core.ResourceRequirements{
 			Requests: defaultResources,
@@ -88,7 +86,6 @@ var paddlesvcCanaryWithSameConfig = elasticservingv1.PaddleService{
 		Namespace: paddleServiceNamespace,
 	},
 	Spec: elasticservingv1.PaddleServiceSpec{
-		DeploymentName: deploymentName,
 		RuntimeVersion: runtimeVersion,
 		Resources: core.ResourceRequirements{
 			Requests: defaultResources,


### PR DESCRIPTION
1. Add more unit tests
2. Delete unrelated code
3. Generally finished.


There exists a known error:
Known error:
Reconciler erro{"controller": "paddleservice", "name": "paddleservice-sample", "namespace": "paddleservice-system", "error": "PaddleService.elasticserving.paddlepaddle.org \"paddleservice-sample\" is invalid: status.conditions.lastTransitionTime: Invalid value: \"string\": status.conditions.lastTransitionTime in body must be of type Any: \"string\""}

This error is triggered by ```conditionSet.Manage(ss).MarkUnknown```, ```conditionSet.Manage(ss).MarkTrue```, ```conditionSet.Manage(ss).MarkFalse```. The is used for PaddleService status propagation and it is temporarily commented out.